### PR TITLE
Fix dockerhub url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,7 @@ Refer to CONTRIBUTING.md for more details.
   https://github.com/ExpediaGroup/pitchfork/blob/master/CONTRIBUTING.md
 -->
 
-Fixes #
+### :pencil: Description
+
+
+### :link: Related Issues

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Please refer to our [CONTRIBUTING](./CONTRIBUTING.md) file.
 
 ## References
 * [Pitchfork Documentation](https://expediagroup.github.io/pitchfork/)
-* [Pitchfork at Docker Hub](https://hub.docker.com/r/expediagroup/pitchfork/)
+* [Pitchfork at Docker Hub](https://hub.docker.com/r/hotelsdotcom/pitchfork/)
 * [Haystack](https://github.com/ExpediaDotCom/haystack/)
 * [Zipkin](https://github.com/openzipkin/zipkin/)
 


### PR DESCRIPTION
### :pencil: Description
- Fixes the DockerHub url in the readme file
- Improves PR template