### PR TITLE
Environment properties with dots

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+src
+website
+docs
+.mvvnw
+.git
+
+.settings
+.idea
+target/classes
+target/test-classes
+target/maven-status
+target/maven-archiver
+target/surefire-reports
+target/generated-sources
+target/generated-test-sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ COPY --from=build /opt/jdk-mini /opt/jdk-mini
 
 # Set our java home and other useful envs
 ENV JAVA_HOME=/opt/jdk-mini
-ARG PATH="$PATH:$JAVA_HOME/bin"
 ARG DIRPATH=/pitchfork
 
 # Create some dirs and copy pitchfork jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ARG JAVA_DOWNLOAD_CHECKSUM=6c06853332585ab58834d9e8a02774b388e6e062ef6c4084b4f058c67f2e81b5
 
-
 # Download java and unpack it
 RUN cd /opt; \
     wget --no-check-certificate https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz \
@@ -41,7 +40,6 @@ ARG DIRPATH=/pitchfork
 RUN mkdir -p $DIRPATH
 COPY target/pitchfork.jar $DIRPATH/
 
-RUN chmod 755 $DIRPATH/pitchfork.jar
 WORKDIR $DIRPATH
 
 # Set timezone (for logs) and run pitchfork

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ COPY --from=build /opt/jdk-mini /opt/jdk-mini
 
 # Set our java home and other useful envs
 ENV JAVA_HOME=/opt/jdk-mini
-ENV PATH="$PATH:$JAVA_HOME/bin"
-ENV DIRPATH /pitchfork
+ARG PATH="$PATH:$JAVA_HOME/bin"
+ARG DIRPATH=/pitchfork
 
 # Create some dirs and copy pitchfork jar
 RUN mkdir -p $DIRPATH
@@ -44,4 +44,9 @@ COPY target/pitchfork.jar $DIRPATH/
 RUN chmod 755 $DIRPATH/pitchfork.jar
 WORKDIR $DIRPATH
 
-CMD ["/bin/bash", "-c", "$JAVA_HOME/bin/java $JAVA_JVM_ARGS -jar pitchfork.jar"]
+# Set timezone (for logs) and run pitchfork
+CMD export TZ=$(date +%Z) &&\
+    exec $JAVA_HOME/bin/java \
+         $JAVA_JVM_ARGS \
+         -jar \
+         pitchfork.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,7 @@ RUN cd /opt; \
     && tar zxf OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz \
     && rm -f OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz
 
-# Set java home and run jlink to create a minimal java distribution with modules required for Spring Boot
-ENV JAVA_HOME=/opt/jdk-14+36
-ENV PATH="$PATH:$JAVA_HOME/bin"
+ENV PATH="$PATH:/opt/jdk-14+36/bin"
 
 RUN jlink \
      --module-path /opt/java/jmods \
@@ -31,17 +29,13 @@ RUN jlink \
 FROM debian:10.3-slim
 COPY --from=build /opt/jdk-mini /opt/jdk-mini
 
-# Set our java home and other useful envs
-ENV JAVA_HOME=/opt/jdk-mini
-ARG DIRPATH=/pitchfork
-
 # Create some dirs and copy pitchfork jar
-COPY target/pitchfork.jar $DIRPATH/
+COPY target/pitchfork.jar /pitchfork/
 
-WORKDIR $DIRPATH
+WORKDIR /pitchfork
 
 # Set timezone (for logs) and run pitchfork
-CMD exec $JAVA_HOME/bin/java \
+CMD exec /opt/jdk-mini/bin/java \
          $JAVA_JVM_ARGS \
          -jar \
          pitchfork.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ ENV JAVA_HOME=/opt/jdk-mini
 ARG DIRPATH=/pitchfork
 
 # Create some dirs and copy pitchfork jar
-RUN mkdir -p $DIRPATH
 COPY target/pitchfork.jar $DIRPATH/
 
 WORKDIR $DIRPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH="$PATH:$JAVA_HOME/bin"
 RUN jlink \
      --module-path /opt/java/jmods \
      --compress=2 \
-     --add-modules jdk.jfr,jdk.management.agent,java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument \
+     --add-modules jdk.jfr,jdk.management.agent,java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.management \
      --no-header-files \
      --no-man-pages \
      --output /opt/jdk-mini
@@ -36,7 +36,6 @@ ENV JAVA_HOME=/opt/jdk-mini
 ENV PATH="$PATH:$JAVA_HOME/bin"
 ENV DIRPATH /pitchfork
 
-
 # Create some dirs and copy pitchfork jar
 RUN mkdir -p $DIRPATH
 COPY target/pitchfork.jar $DIRPATH/
@@ -44,9 +43,4 @@ COPY target/pitchfork.jar $DIRPATH/
 RUN chmod 755 $DIRPATH/pitchfork.jar
 WORKDIR $DIRPATH
 
-# Set timezone (for logs) and run pitchfork
-CMD export TZ=$(date +%Z) &&\
-    exec $JAVA_HOME/bin/java \
-         $JAVA_JVM_ARGS \
-         -jar \
-         pitchfork.jar
+CMD ["/bin/bash", "-c", "$JAVA_HOME/bin/java $JAVA_JVM_ARGS -jar pitchfork.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ COPY target/pitchfork.jar $DIRPATH/
 WORKDIR $DIRPATH
 
 # Set timezone (for logs) and run pitchfork
-CMD export TZ=$(date +%Z) &&\
-    exec $JAVA_HOME/bin/java \
+CMD exec $JAVA_HOME/bin/java \
          $JAVA_JVM_ARGS \
          -jar \
          pitchfork.jar

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -122,9 +122,9 @@ You can also use the following properties to add tag to the metrics and (for uni
 This is useful if you have multiple instances of Pitchfork running and you would want your metrics to look like this: `pitchfork.instance-01.metric-name=123`
 
 ```
-MANAGEMENT_METRICS_MANAGEMENT_METRICS_TAGS_APP=pitchfork
-MANAGEMENT_METRICS_MANAGEMENT_METRICS_TAGS_INSTANCE=instance-01
-MANAGEMENT_METRICS_MANAGEMENT_METRICS_EXPORT_GRAPHITE_TAGS_AS_PREFIX=APP,INSTANCE
+MANAGEMENT_METRICS_TAGS_APP=pitchfork
+MANAGEMENT_METRICS_TAGS_INSTANCE=instance-01
+MANAGEMENT_METRICS_EXPORT_GRAPHITE_TAGS_AS_PREFIX=APP,INSTANCE
 ```
 
 ### Validators

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -72,7 +72,7 @@ Kinesis output is disabled by default. You can enable and configure it using the
 | PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_CLIENT_ENDPOINT_SIGNING_REGION_NAME | us-west-1                               | Used when kinesis client config-type is ENDPOINT. The region to use for signing of requests                                 |
 | PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_CONFIG_TYPE                    | DEFAULT                                 | Authentication method to use. Possible values are DEFAULT or BASIC                                                          |
 | PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_BASIC_AWS_ACCESS_KEY           | accesskey                               | Used when authentication-type is BASIC. The AWS access key                                                                  |
-| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_basic_AWS_SECRET_KEY           | secretkey                               | Used when authentication-type is BASIC. The AWS secret access key                                                           |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_BASIC_AWS_SECRET_KEY           | secretkey                               | Used when authentication-type is BASIC. The AWS secret access key                                                           |
 
 ### Zipkin HTTP
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -11,7 +11,7 @@ HTTP is the default ingress and is always enabled. The following properties can 
 
 | Property name | Default value | Description                            |
 |:--------------|:--------------|:---------------------------------------|
-| server.port   | 9411          | HTTP port where Pitchfork is listening |
+| SERVER_PORT   | 9411          | HTTP port where Pitchfork is listening |
 
 ### Kafka
 
@@ -19,16 +19,16 @@ Kafka ingress is disabled by default. You can enable and configure it using the 
 
 | Property name                                   | Default value      | Description                                                                                                                                                      |
 |:------------------------------------------------|:-------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| pitchfork.ingress.kafka.enabled                 | false              | If enabled Pitchfork will read Zipkin spans from the configured Kafka topic                                                                                      |
-| pitchfork.ingress.kafka.bootstrap-servers       | kafka-service:9092 | A list of host/port pairs to use for establishing the initial connection to the Kafka cluster                                                                    |
-| pitchfork.ingress.kafka.number-consumers        | 4                  | The number of consumer threads polling Kafka                                                                                                                     |
-| pitchfork.ingress.kafka.enable-auto-commit      | true               | If true the consumer's offset will be periodically committed in the background                                                                                   |
-| pitchfork.ingress.kafka.auto-commit-internal-ms | 1000               | The frequency in milliseconds that the consumer offsets are auto-committed to Kafka                                                                              |
-| pitchfork.ingress.kafka.poll-duration-ms        | 1000               | The maximum time to block waiting for new records                                                                                                                |
-| pitchfork.ingress.kafka.auto-offset-reset       | earliest           | What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. Possible values are earliest, latest or none |
-| pitchfork.ingress.kafka.session-timeout-ms      | 60000              | The timeout used to detect consumer failures when using Kafka's group management facility                                                                        |
-| pitchfork.ingress.kafka.source-topics           | zipkin             | List of Kafka topics to subscribe to                                                                                                                             |
-| pitchfork.ingress.kafka.source-format           | JSON_V2            | Format/encoding of the spans in the Kafka topic. Possible values are JSON_V1, THRIFT, JSON_V2 or PROTO3                                                          |
+| PITCHFORK_INGRESS_KAFKA_ENABLED                 | false              | If enabled Pitchfork will read Zipkin spans from the configured Kafka topic                                                                                      |
+| PITCHFORK_INGRESS_KAFKA_BOOTSTRAP_SERVERS       | kafka-service:9092 | A list of host/port pairs to use for establishing the initial connection to the Kafka cluster                                                                    |
+| PITCHFORK_INGRESS_KAFKA_NUMBER_CONSUMERS        | 4                  | The number of consumer threads polling Kafka                                                                                                                     |
+| PITCHFORK_INGRESS_KAFKA_ENABLE_AUTO_COMMIT      | true               | If true the consumer's offset will be periodically committed in the background                                                                                   |
+| PITCHFORK_INGRESS_KAFKA_AUTO_COMMIT_INTERNAL_MS | 1000               | The frequency in milliseconds that the consumer offsets are auto-committed to Kafka                                                                              |
+| PITCHFORK_INGRESS_KAFKA_POLL_DURATION_MS        | 1000               | The maximum time to block waiting for new records                                                                                                                |
+| PITCHFORK_INGRESS_KAFKA_AUTO_OFFSET_RESET       | earliest           | What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. Possible values are earliest, latest or none |
+| PITCHFORK_INGRESS_KAFKA_SESSION_TIMEOUT_MS      | 60000              | The timeout used to detect consumer failures when using Kafka's group management facility                                                                        |
+| PITCHFORK_INGRESS_KAFKA_SOURCE_TOPICS           | zipkin             | List of Kafka topics to subscribe to                                                                                                                             |
+| PITCHFORK_INGRESS_KAFKA_SOURCE_FORMAT           | JSON_V2            | Format/encoding of the spans in the Kafka topic. Possible values are JSON_V1, THRIFT, JSON_V2 or PROTO3                                                          |
 {: .tablelines}
 
 ### RabbitMQ
@@ -37,14 +37,14 @@ RabbitMQ ingress is disabled by default. You can enable and configure it using t
 
 | Property name                            | Default value | Description                                                                                                |
 |:-----------------------------------------|:--------------|:-----------------------------------------------------------------------------------------------------------|
-| pitchfork.ingress.rabbitmq.enabled       | false         | If enabled Pitchfork will read Zipkin spans from the configured RabbitMQ queue                             |
-| pitchfork.ingress.rabbitmq.user          | guest         | The user name to use when connecting to the broker                                                         |
-| pitchfork.ingress.rabbitmq.password      | guest         | The password to use when connecting to the broker                                                          |
-| pitchfork.ingress.rabbitmq.virtual-host  | /             | The virtual host to use for connections                                                                    |
-| pitchfork.ingress.rabbitmq.host          | localhost     | The host for the broker                                                                                    |
-| pitchfork.ingress.rabbitmq.port          | 5762          | The port for the broker                                                                                    |
-| pitchfork.ingress.rabbitmq.queue-name    | zipkin        | The name of the queue to read spans from                                                                   |
-| pitchfork.ingress.rabbitmq.source-format | JSON_V2       | Format/encoding of the spans in the RabbitMQ queue. Possible values are JSON_V1, THRIFT, JSON_V2 or PROTO3 |
+| PITCHFORK_INGRESS_RABBITMQ_ENABLED       | false         | If enabled Pitchfork will read Zipkin spans from the configured RabbitMQ queue                             |
+| PITCHFORK_INGRESS_RABBITMQ_USER          | guest         | The user name to use when connecting to the broker                                                         |
+| PITCHFORK_INGRESS_RABBITMQ_PASSWORD      | guest         | The password to use when connecting to the broker                                                          |
+| PITCHFORK_INGRESS_RABBITMQ_VIRTUAL_HOST  | /             | The virtual host to use for connections                                                                    |
+| PITCHFORK_INGRESS_RABBITMQ_HOST          | localhost     | The host for the broker                                                                                    |
+| PITCHFORK_INGRESS_RABBITMQ_PORT          | 5762          | The port for the broker                                                                                    |
+| PITCHFORK_INGRESS_RABBITMQ_QUEUE_NAME    | zipkin        | The name of the queue to read spans from                                                                   |
+| PITCHFORK_INGRESS_RABBITMQ_SOURCE_FORMAT | JSON_V2       | Format/encoding of the spans in the RabbitMQ queue. Possible values are JSON_V1, THRIFT, JSON_V2 or PROTO3 |
 
 ## Configuring different outputs
 
@@ -54,9 +54,9 @@ Kafka output is disabled by default. You can enable and configure it using the f
 
 | Property name                                         | Default value      | Description                                                                                   |
 |:------------------------------------------------------|:-------------------|:----------------------------------------------------------------------------------------------|
-| pitchfork.forwarders.haystack.kafka.enabled           | false              | If enabled Pitchfork will forward spans to a Kafka broker                                     |
-| pitchfork.forwarders.haystack.kafka.bootstrap-servers | kafka-service:9092 | A list of host/port pairs to use for establishing the initial connection to the Kafka cluster |
-| pitchfork.forwarders.haystack.kafka.topic             | proto-spans        | The name of the Kafka topic where the spans will be submitted to                              |
+| PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_ENABLED           | false              | If enabled Pitchfork will forward spans to a Kafka broker                                     |
+| PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_BOOTSTRAP_SERVERS | kafka-service:9092 | A list of host/port pairs to use for establishing the initial connection to the Kafka cluster |
+| PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_TOPIC             | proto-spans        | The name of the Kafka topic where the spans will be submitted to                              |
 
 ### Kinesis
 
@@ -64,15 +64,15 @@ Kinesis output is disabled by default. You can enable and configure it using the
 
 | Property name                                                             | Default value                           | Description                                                                                                                 |
 |:--------------------------------------------------------------------------|:----------------------------------------|:----------------------------------------------------------------------------------------------------------------------------|
-| pitchfork.forwarders.haystack.kinesis.enabled                             | false                                   | If enabled Pitchfork will forward spans to a Kinesis stream                                                                 |
-| pitchfork.forwarders.haystack.kinesis.stream-name                         | proto-spans                             | The name of the Kinesis stream where the spans will be submitted to                                                         |
-| pitchfork.forwarders.haystack.kinesis.client.config-type                  | REGION                                  | What type of endpoint configuration to use. Possible values are REGION or ENDPOINT                                          |
-| pitchfork.forwarders.haystack.kinesis.client.region.region-name           | us-west-1                               | Used when the kinesis client config-type is REGION. Region is used to determine the service endpoint and the signing region |
-| pitchfork.forwarders.haystack.kinesis.client.endpoint.service-endpoint    | https://kinesis.us-west-1.amazonaws.com | Used when kinesis client config-type is ENDPOINT. The service endpoint (with or without protocol)                           |
-| pitchfork.forwarders.haystack.kinesis.client.endpoint.signing-region-name | us-west-1                               | Used when kinesis client config-type is ENDPOINT. The region to use for signing of requests                                 |
-| pitchfork.forwarders.haystack.kinesis.auth.config-type                    | DEFAULT                                 | Authentication method to use. Possible values are DEFAULT or BASIC                                                          |
-| pitchfork.forwarders.haystack.kinesis.auth.basic.aws-access-key           | accesskey                               | Used when authentication-type is BASIC. The AWS access key                                                                  |
-| pitchfork.forwarders.haystack.kinesis.auth.basic.aws-secret-key           | secretkey                               | Used when authentication-type is BASIC. The AWS secret access key                                                           |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_ENABLED                             | false                                   | If enabled Pitchfork will forward spans to a Kinesis stream                                                                 |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_STREAM_NAME                         | proto-spans                             | The name of the Kinesis stream where the spans will be submitted to                                                         |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_CLIENT_CONFIG_TYPE                  | REGION                                  | What type of endpoint configuration to use. Possible values are REGION or ENDPOINT                                          |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_CLIENT_REGION_REGION_NAME           | us-west-1                               | Used when the kinesis client config-type is REGION. Region is used to determine the service endpoint and the signing region |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_CLIENT_ENDPOINT_SERVICE_ENDPOINT    | https://kinesis.us-west-1.amazonaws.com | Used when kinesis client config-type is ENDPOINT. The service endpoint (with or without protocol)                           |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_CLIENT_ENDPOINT_SIGNING_REGION_NAME | us-west-1                               | Used when kinesis client config-type is ENDPOINT. The region to use for signing of requests                                 |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_CONFIG_TYPE                    | DEFAULT                                 | Authentication method to use. Possible values are DEFAULT or BASIC                                                          |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_BASIC_AWS_ACCESS_KEY           | accesskey                               | Used when authentication-type is BASIC. The AWS access key                                                                  |
+| PITCHFORK_FORWARDERS_HAYSTACK_KINESIS_AUTH_basic_AWS_SECRET_KEY           | secretkey                               | Used when authentication-type is BASIC. The AWS secret access key                                                           |
 
 ### Zipkin HTTP
 
@@ -80,13 +80,13 @@ Zipkin output is disabled by default. You can enable and configure it using the 
 
 | Property name                                          | Default value                      | Description                                                                     |
 |:-------------------------------------------------------|:-----------------------------------|:--------------------------------------------------------------------------------|
-| pitchfork.forwarders.zipkin.http.enabled               | false                              | If enabled Pitchfork will forward spans to an HTTP Zipkin server                |
-| pitchfork.forwarders.zipkin.http.endpoint              | http://localhost:9411/api/v2/spans | The POST url for the Zipkin http reporter                                       |
-| pitchfork.forwarders.zipkin.http.max-inflight-requests | 256                                | Number of max inflight requests                                                 |
-| pitchfork.forwarders.zipkin.http.write-timeout-millis  | 10000                              | Write timeout in milliseconds                                                   |
-| pitchfork.forwarders.zipkin.http.compression-enabled   | true                               | Set to true for spans to be gzipped before transport                            |
-| pitchfork.forwarders.zipkin.http.max-idle-connections  | 50                                 | Max idle connections for the Zipkin reporter connection pool                    |
-| pitchfork.forwarders.zipkin.http.ignore-ssl-errors     | false                              | When true, ignores all SSL errors when connecting to the upstream Zipkin server |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_ENABLED               | false                              | If enabled Pitchfork will forward spans to an HTTP Zipkin server                |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_ENDPOINT              | http://localhost:9411/api/v2/spans | The POST url for the Zipkin http reporter                                       |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_MAX_INFLIGHT_REQUESTS | 256                                | Number of max inflight requests                                                 |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_WRITE_TIMEOUT_MILLIS  | 10000                              | Write timeout in milliseconds                                                   |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_COMPRESSION_ENABLED   | true                               | Set to true for spans to be gzipped before transport                            |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_MAX_IDLE_CONNECTIONS  | 50                                 | Max idle connections for the Zipkin reporter connection pool                    |
+| PITCHFORK_FORWARDERS_ZIPKIN_HTTP_IGNORE_SSL_ERRORS     | false                              | When true, ignores all SSL errors when connecting to the upstream Zipkin server |
 
 ## Other options
 
@@ -97,14 +97,14 @@ It may be useful to enable the logging of spans for troubleshooting.
 To enable the logging of just the trace id:
 
 ```yaml
-pitchfork.forwarders.logging.enabled=true
+PITCHFORK_FORWARDERS_LOGGING_ENABLED=true
 ```
 
 To enable the logging of the entire span received:
 
 ```yaml
-pitchfork.forwarders.logging.enabled=true
-pitchfork.forwarders.logging.log-full-span=true
+PITCHFORK_FORWARDERS_LOGGING_ENABLED=true
+PITCHFORK_FORWARDERS_LOGGING_LOG_FULL_SPAN=true
 ```
 
 ### Metrics
@@ -113,18 +113,18 @@ By default Pitchfork exposes both a /metrics and a /prometheus endpoint (see sec
 You can also report data to a Graphite collector by configuring the host and port:
 
 ```
-management.metrics.export.graphite.enabled=true
-management.metrics.export.graphite.host=graphite.example.com
-management.metrics.export.graphite.port=9004
+MANAGEMENT_METRICS_EXPORT_GRAPHITE_ENABLED=true
+MANAGEMENT_METRICS_EXPORT_GRAPHITE_HOST=graphite.example.com
+MANAGEMENT_METRICS_EXPORT_GRAPHITE_PORT=9004
 ```
 
 You can also use the following properties to add tag to the metrics and (for unidimensional systems like graphite) convert them into prefixes.
-This is useful if you have multiple instances of Pitchfork running and you would want your metrics to look like this: `pitchfork.instance-01.metric-name=123` 
+This is useful if you have multiple instances of Pitchfork running and you would want your metrics to look like this: `pitchfork.instance-01.metric-name=123`
 
 ```
-management.metrics.tags.application=pitchfork
-management.metrics.tags.instance=instance-01
-management.metrics.export.graphite.tags-as-prefix=application,instance
+MANAGEMENT_METRICS_MANAGEMENT_METRICS_TAGS_APP=pitchfork
+MANAGEMENT_METRICS_MANAGEMENT_METRICS_TAGS_INSTANCE=instance-01
+MANAGEMENT_METRICS_MANAGEMENT_METRICS_EXPORT_GRAPHITE_TAGS_AS_PREFIX=APP,INSTANCE
 ```
 
 ### Validators
@@ -132,15 +132,15 @@ management.metrics.export.graphite.tags-as-prefix=application,instance
 You can also configure Pitchfork to discard spans with a null timestamp:
 
 ```yaml
-pitchfork.validators.accept-null-timestamps=false
+PITCHFORK_VALIDATORS_ACCEPT_NULL_TIMESTAMPS=false
 ```
 
-Or to discard spans if the difference between the timestamp of the span and the timestamp of the server is over x seconds. 
+Or to discard spans if the difference between the timestamp of the span and the timestamp of the server is over x seconds.
 
 Example for 60 seconds (-1 to disable):
 
 ```yaml
-max-timestamp-drift-seconds=60
+MAX_TIMESTAMP_DRIFT_SECONDS=60
 ```
 
 ### Endpoints

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/haystack/SpanValidator.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/haystack/SpanValidator.java
@@ -43,8 +43,8 @@ public class SpanValidator {
     private Counter invalidSpansCounter;
 
     public SpanValidator(@Value("${pitchfork.validators.accept-null-timestamps}") boolean acceptNullTimestamps,
-            @Value("${pitchfork.validators.max-timestamp-drift-seconds}") int maxTimestampDriftSeconds,
-            MetersProvider metersProvider) {
+                         @Value("${pitchfork.validators.max-timestamp-drift-seconds}") int maxTimestampDriftSeconds,
+                         MetersProvider metersProvider) {
         this.acceptNullTimestamps = acceptNullTimestamps;
         this.maxTimestampDriftSeconds = maxTimestampDriftSeconds;
         this.metersProvider = metersProvider;


### PR DESCRIPTION
### :pencil: Description
Environment properties with periods are not passed to pitchfork.
This was the case for Alpine for some time but it looks like it's also happening for Debian now.
There are several tickets with more details about this issue (e.g.: https://github.com/docker-library/openjdk/issues/135) but in short the alternatives are:
- promote the usage of POSIX names (underscore + uppercase)
- use bash

I'm opening this pr to get some feedback on the pros and cons of both.