### PR TITLE
Typo in docs (k8s example)

### DIFF
--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -71,7 +71,7 @@ spec:
             - name: MANAGEMENT_METRICS_TAGS_INSTANCE
               value: $(POD_NAME)
             - name: MANAGEMENT_METRICS_EXPORT_GRAPHITE_TAGS_AS_PREFIX
-              value: "APP,INSTANCE"
+              value: "app,instance"
             # Isolating actuator endpoints. This allows Pitchfork to handle healthchecks even when under extremely high load.
             - name: MANAGEMENT_SERVER_PORT
               value: "8081"


### PR DESCRIPTION
### :pencil: Description
Typo in docs (kubernetes example)
