### PR TITLE
Added helm charts. Fixes ExpediaGroup/pitchfork#12

### DIFF
--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -145,3 +145,7 @@ spec:
         type: Utilization
         averageUtilization: 30
 ```
+
+### Helm charts
+
+We have helm charts which will help you get up and running quickly. You can access them under ```kube-apps``` folder.

--- a/kube-apps/pitchfork/.helmignore
+++ b/kube-apps/pitchfork/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kube-apps/pitchfork/Chart.yaml
+++ b/kube-apps/pitchfork/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: pitchfork
+description: Pitchfork lifts Zipkin tracing data into Haystack.
+version: 0.1.0
+appVersion: 1.16.0

--- a/kube-apps/pitchfork/templates/NOTES.txt
+++ b/kube-apps/pitchfork/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "pitchfork.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "pitchfork.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "pitchfork.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "pitchfork.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/kube-apps/pitchfork/templates/_helpers.tpl
+++ b/kube-apps/pitchfork/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pitchfork.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pitchfork.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pitchfork.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pitchfork.labels" -}}
+helm.sh/chart: {{ include "pitchfork.chart" . }}
+{{ include "pitchfork.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pitchfork.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pitchfork.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pitchfork.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pitchfork.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/kube-apps/pitchfork/templates/deployment.yaml
+++ b/kube-apps/pitchfork/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
             periodSeconds: {{ .Values.service.readinessProbe.periodSeconds }}
           lifecycle:
             {{- toYaml .Values.service.lifecycle | nindent 12 }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kube-apps/pitchfork/templates/deployment.yaml
+++ b/kube-apps/pitchfork/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pitchfork.fullname" . }}
+  labels:
+    {{- include "pitchfork.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "pitchfork.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "pitchfork.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.service.healthCheckPort }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- toYaml .Values.service.env | nindent 12 }}
+          resources:
+            {{- toYaml .Values.service.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.service.livenessProbe.httpGet.path }}
+              port: {{ .Values.service.healthCheckPort }}
+            initialDelaySeconds: {{ .Values.service.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.service.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.service.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.service.readinessProbe.httpGet.path }}
+              port: {{ .Values.service.healthCheckPort }}
+            initialDelaySeconds: {{ .Values.service.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.service.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.service.readinessProbe.periodSeconds }}
+          lifecycle:
+            {{- toYaml .Values.service.lifecycle | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/kube-apps/pitchfork/templates/hpa.yaml
+++ b/kube-apps/pitchfork/templates/hpa.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "pitchfork.fullname" . }}
+  labels:
+    {{- include "pitchfork.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v2beta1
+    kind: Deployment
+    name: {{ include "pitchfork.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/kube-apps/pitchfork/templates/service.yaml
+++ b/kube-apps/pitchfork/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pitchfork.fullname" . }}
+  labels:
+    {{- include "pitchfork.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    {{- include "pitchfork.selectorLabels" . | nindent 4 }}

--- a/kube-apps/pitchfork/values.yaml
+++ b/kube-apps/pitchfork/values.yaml
@@ -1,0 +1,90 @@
+replicaCount: 1
+
+image:
+  repository: expediagroup/pitchfork
+  pullPolicy: Always
+  tag: "1.21"
+
+imagePullSecrets: []
+nameOverride: "pitchfork"
+fullnameOverride: "pitchfork"
+labels:
+  - app: pitchfork
+  - release: pitchfork
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8081"
+  prometheus.io/path: "/actuator/prometheus"
+
+ingress:
+  enabled : false
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  name: app-port
+  type: ClusterIP
+  port: 9411
+  healthCheckPort: 8081
+  env:
+    - name: SERVER_PORT
+      value: "9411"
+    # If you are familiar with the JVM you can tune memory and settings here. If not, these should give you an overall decent experience.
+    - name: JAVA_JVM_ARGS
+      value: "-XX:MaxRAMPercentage=80.0"
+    # If you are not using Kafka or if you do not care about capturing metrics for the Kafka consumers/producers you can disable this option
+    - name: SPRING_JMX_ENABLED
+      value: "true"
+    # You can enabled and configure more forwarders here.
+    - name: PITCHFORK_FORWARDERS_LOGGING_ENABLED
+      value: "true"
+    # The following properties are use to tag metrics produced by Pitchfork with the app name and with the name of the pod.
+    - name: MANAGEMENT_METRICS_TAGS_APP
+      value: "pitchfork"
+    - name: MANAGEMENT_METRICS_TAGS_INSTANCE
+      value: $(POD_NAME)
+    - name: MANAGEMENT_METRICS_EXPORT_GRAPHITE_TAGS_AS_PREFIX
+      value: "app,instance"
+    # Isolating actuator endpoints. This allows Pitchfork to handle healthchecks even when under extremely high load.
+    - name: MANAGEMENT_SERVER_PORT
+      value: "8081"
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 1
+      memory: 1Gi
+  livenessProbe:
+    httpGet:
+      path: /info
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 30
+  readinessProbe:
+    httpGet:
+      path: /health
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 30
+  lifecycle:
+    preStop:
+      exec:
+        command: [ "/bin/sleep", "20"]
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 30
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceAccount:
+  create: false

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,7 @@
     <aws-java-sdk.version>1.11.756</aws-java-sdk.version>
     <zipkin-reporter.version>2.12.1</zipkin-reporter.version>
     <spring-boot.version>2.2.5.RELEASE</spring-boot.version>
-    <spring-test.version>5.2.3.RELEASE</spring-test.version>
-    <junit-jupiter.version>5.6.0</junit-jupiter.version>
-    <mockito.version>3.3.0</mockito.version>
     <testcontainers.version>1.12.5</testcontainers.version>
-    <micrometer.version>1.4.1</micrometer.version>
-    <netty-codec.version>4.1.48.Final</netty-codec.version>
     <jackson.version>2.10.2</jackson.version>
     <amazon-kinesis-producer.version>0.14.0</amazon-kinesis-producer.version>
     <amazon-kinesis-client.version>1.13.2</amazon-kinesis-client.version>
@@ -28,7 +23,6 @@
     <haystack-idl.version>1.0.66</haystack-idl.version>
     <zipkin-proto.version>0.2.2</zipkin-proto.version>
     <kafka.version>2.4.0</kafka.version>
-    <logback-classic.version>1.2.3</logback-classic.version>
     <protobuf-java.version>3.11.4</protobuf-java.version>
     <javax-annotation.version>1.3.2</javax-annotation.version>
     <awaitility.version>4.0.2</awaitility.version>
@@ -57,6 +51,15 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>io.zipkin.reporter2</groupId>
         <artifactId>zipkin-reporter-bom</artifactId>
         <version>${zipkin-reporter.version}</version>
@@ -78,12 +81,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
-      <version>${spring-boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>${spring-boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -99,7 +100,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback-classic.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -111,40 +111,11 @@
       <artifactId>javax.inject</artifactId>
       <version>1</version>
     </dependency>
-
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <version>${javax-annotation.version}</version>
     </dependency>
 
-    <!-- Metrics -->
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-      <version>${micrometer.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>${micrometer.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-jmx</artifactId>
-      <version>${micrometer.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-graphite</artifactId>
-      <version>${micrometer.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-      <version>${netty-codec.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
@@ -163,12 +134,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>
@@ -184,18 +153,34 @@
       <artifactId>haystack-idl-java</artifactId>
       <version>${haystack-idl.version}</version>
     </dependency>
-
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
       <version>${rabbitmq-client.version}</version>
     </dependency>
 
+    <!-- Metrics -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-jmx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-graphite</artifactId>
+    </dependency>
+
     <!-- Compile time dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
-      <version>${spring-boot.version}</version>
       <optional>true</optional>
     </dependency>
 
@@ -227,37 +212,31 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
-      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>${spring-test.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### :pencil: Description
Added helm charts under kube-apps/pitchfork.
Current charts matches the ones in documentation for the most part (excluding the kafka forwarder)

### :link: Related Issues
#12 