### PR TITLE
Reduce noise on errors

### DIFF
--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/zipkin/http/ZipkinForwarder.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/zipkin/http/ZipkinForwarder.java
@@ -103,7 +103,8 @@ public class ZipkinForwarder implements SpanForwarder {
         @Override
         public void onError(Throwable t) {
             failureCounter.increment();
-            logger.error("Unable to write span {}", span.id(), t);
+            logger.debug("Unable to write span {}", span.id(), t);
+            logger.error("Unable to write span {} with error {}", span.id(), t.getMessage());
         }
     }
 }


### PR DESCRIPTION
### :pencil: Description
When using Pitchfork as a forwarder to Zipkin and the upstream is unavailable, this can create a massive amount of log noise.
With this change we only log the error message and not the entire stack trace. It's still possible to see the stack trace (if you like spam) by dropping the log level via JMX.