### PR TITLE
Fix flaky tests

### DIFF
--- a/src/test/java/com/hotels/service/tracing/zipkintohaystack/HaystackKafkaForwarderTest.java
+++ b/src/test/java/com/hotels/service/tracing/zipkintohaystack/HaystackKafkaForwarderTest.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -23,6 +24,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import static java.time.Duration.ofSeconds;
@@ -42,6 +44,10 @@ class HaystackKafkaForwarderTest {
 
     @Container
     private static final KafkaContainer kafkaContainer = new KafkaContainer();
+    private static final ConditionFactory AWAIT = await()
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofSeconds(1))
+            .pollDelay(Duration.ofSeconds(1));
 
     @LocalServerPort
     private int localServerPort;
@@ -79,7 +85,7 @@ class HaystackKafkaForwarderTest {
 
         // proxy is async, and kafka is async too, so we retry our assertions until they are true
         try (KafkaConsumer<String, byte[]> consumer = setupConsumer()) {
-            await().atMost(10, SECONDS).untilAsserted(() -> {
+            AWAIT.untilAsserted(() -> {
                 ConsumerRecords<String, byte[]> records = consumer.poll(ofSeconds(1));
 
                 assertThat(records).isNotEmpty();

--- a/src/test/java/com/hotels/service/tracing/zipkintohaystack/KafkaIngressTest.java
+++ b/src/test/java/com/hotels/service/tracing/zipkintohaystack/KafkaIngressTest.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -22,6 +23,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.kafka.KafkaSender;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import static java.time.Duration.ofSeconds;
@@ -41,6 +43,10 @@ class KafkaIngressTest {
 
     @Container
     private static final KafkaContainer kafkaContainer = new KafkaContainer();
+    private static final ConditionFactory AWAIT = await()
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofSeconds(1))
+            .pollDelay(Duration.ofSeconds(1));
 
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         public void initialize(ConfigurableApplicationContext context) {
@@ -78,7 +84,7 @@ class KafkaIngressTest {
 
         // proxy is async, and kafka is async too, so we retry our assertions until they are true
         try (KafkaConsumer<String, byte[]> consumer = setupConsumer()) {
-            await().atMost(10, SECONDS).untilAsserted(() -> {
+            AWAIT.untilAsserted(() -> {
                 ConsumerRecords<String, byte[]> records = consumer.poll(ofSeconds(1));
 
                 assertThat(records).isNotEmpty();

--- a/src/test/java/com/hotels/service/tracing/zipkintohaystack/ZipkinForwarderTest.java
+++ b/src/test/java/com/hotels/service/tracing/zipkintohaystack/ZipkinForwarderTest.java
@@ -1,5 +1,6 @@
 package com.hotels.service.tracing.zipkintohaystack;
 
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,6 +24,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
+import java.time.Duration;
 import java.util.List;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -43,6 +45,10 @@ class ZipkinForwarderTest {
     private static final GenericContainer zipkinContainer = new GenericContainer("openzipkin/zipkin:2.12")
             .withExposedPorts(9411)
             .waitingFor(new HttpWaitStrategy().forPath("/health"));
+    private static final ConditionFactory AWAIT = await()
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofSeconds(1))
+            .pollDelay(Duration.ofSeconds(1));
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -80,7 +86,7 @@ class ZipkinForwarderTest {
         reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
-        await().atMost(10, SECONDS).untilAsserted(() -> {
+        AWAIT.untilAsserted(() -> {
 
             // assert that traces were forwarded to zipkin by asking which services it knows about
             ResponseEntity<String> responseFromZipkin = restTemplate
@@ -115,7 +121,7 @@ class ZipkinForwarderTest {
         reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
-        await().atMost(10, SECONDS).untilAsserted(() -> {
+        AWAIT.untilAsserted(() -> {
 
             // assert that traces were forwarded to zipkin by asking which services it knows about
             ResponseEntity<String> responseFromZipkin = restTemplate
@@ -150,7 +156,7 @@ class ZipkinForwarderTest {
         reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
-        await().atMost(10, SECONDS).untilAsserted(() -> {
+        AWAIT.untilAsserted(() -> {
 
             // assert that traces were forwarded to zipkin by asking which services it knows about
             ResponseEntity<String> responseFromZipkin = restTemplate
@@ -190,8 +196,7 @@ class ZipkinForwarderTest {
         assertThat(HttpStatus.OK).isEqualTo(responseFromVictim.getStatusCode()).withFailMessage("Expected a 200 status from pitchfork");
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
-        await().atMost(10, SECONDS).untilAsserted(() -> {
-
+        AWAIT.untilAsserted(() -> {
             // assert that traces were forwarded to zipkin by asking which services it knows about
             ResponseEntity<String> responseFromZipkin = restTemplate
                     .getForEntity(
@@ -225,7 +230,7 @@ class ZipkinForwarderTest {
         reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
-        await().atMost(10, SECONDS).untilAsserted(() -> {
+        AWAIT.untilAsserted(() -> {
 
             // assert that traces were forwarded to zipkin by asking which services it knows about
             ResponseEntity<String> responseFromZipkin = restTemplate


### PR DESCRIPTION
### :pencil: Description
- Fix flaky tests (Kinesis tests were attempting to use a stream that had not been created yet).
- Add an internal and initial pool delay for awaitility checks
