### PR TITLE
Fix double counter

### DIFF
--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
@@ -16,12 +16,10 @@
  */
 package com.hotels.service.tracing.zipkintohaystack;
 
-import static org.springframework.web.reactive.function.server.ServerResponse.notFound;
-import static org.springframework.web.reactive.function.server.ServerResponse.ok;
-
-import java.util.Collection;
-import java.util.function.Function;
-
+import com.hotels.service.tracing.zipkintohaystack.forwarders.Fork;
+import com.hotels.service.tracing.zipkintohaystack.forwarders.SpanForwarder;
+import com.hotels.service.tracing.zipkintohaystack.forwarders.haystack.SpanValidator;
+import io.micrometer.core.instrument.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,14 +28,15 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
-
-import com.hotels.service.tracing.zipkintohaystack.forwarders.Fork;
-import com.hotels.service.tracing.zipkintohaystack.forwarders.SpanForwarder;
-import com.hotels.service.tracing.zipkintohaystack.forwarders.haystack.SpanValidator;
-import io.micrometer.core.instrument.Counter;
 import reactor.core.publisher.Mono;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesDecoder;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import static org.springframework.web.reactive.function.server.ServerResponse.notFound;
+import static org.springframework.web.reactive.function.server.ServerResponse.ok;
 
 @RestController
 public class ZipkinController {
@@ -73,7 +72,7 @@ public class ZipkinController {
                 .bodyToMono(byte[].class)
                 .flatMapIterable(decodeList(decoder))
                 .filter(spanValidator::isSpanValid)
-                .doOnComplete(counter::increment)
+                .doOnNext(span -> counter.increment())
                 .doOnError(throwable -> logger.warn("operation=addSpans", throwable))
                 .doOnNext(fork::processSpan)
                 .then(ok().body(BodyInserters.empty()));

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
@@ -73,7 +73,7 @@ public class ZipkinController {
                 .bodyToMono(byte[].class)
                 .flatMapIterable(decodeList(decoder))
                 .filter(spanValidator::isSpanValid)
-                .doOnEach(spanSignal -> counter.increment())
+                .doOnComplete(counter::increment)
                 .doOnError(throwable -> logger.warn("operation=addSpans", throwable))
                 .doOnNext(fork::processSpan)
                 .then(ok().body(BodyInserters.empty()));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,3 +108,5 @@ info:
 spring:
   application:
     name: pitchfork
+  codec:
+    max-in-memory-size: 10MB


### PR DESCRIPTION
### :pencil: Description
- We get an extra signal with doOnEach (onCompleted) which is incorrectly increasing the number of spans processed.
- Also using this pr to set a higher max in mem size for reactive codecs as this causes issues when processing requests with large amounts of spans.