### PR TITLE
added gh action for publishing docker images

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: '14'
+        architecture: x64
+    - name: Build with Maven
+      run: ./mvnw clean package
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
+      with:
+        username: vthakurdocker
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: vthakurdocker/pitchfork
+        tags: latest_gh


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/pitchfork#build
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/pitchfork/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
- Closes #24 
- Integrated with GH action for publishing docker images
- verified docker push by using https://github.com/nektos/act and personal docker io [account](https://registry.hub.docker.com/layers/vthakurdocker/pitchfork/latest_gh/images/sha256-156431c7e7c8641829db9cf061aa057e3f1e0ff347b34f15953155b4ceee7bb4?context=explore)

### :link: Related Issues
- need to update credentials with official EG docker account