### PR TITLE
Add additional validator and metrics for datadog

### DIFF
--- a/docs/installation/configuration-options.md
+++ b/docs/installation/configuration-options.md
@@ -155,7 +155,15 @@ Or to discard spans if the difference between the timestamp of the span and the 
 Example for 60 seconds (-1 to disable):
 
 ```
-MAX_TIMESTAMP_DRIFT_SECONDS=60
+PITCHFORK_VALIDATORS_MAX_TIMESTAMP_DRIFT_SECONDS=60
+```
+
+Or even to discard spans from specific services.
+
+Example for two disallowed service names:
+
+```
+PITCHFORK_VALIDATORS_INVALID_SERVICE_NAMES=unknown,empty
 ```
 
 ## Overriding JVM Options with Docker

--- a/src/main/java/com/expedia/pitchfork/ZipkinController.java
+++ b/src/main/java/com/expedia/pitchfork/ZipkinController.java
@@ -18,7 +18,7 @@ package com.expedia.pitchfork;
 
 import com.expedia.pitchfork.systems.common.Fork;
 import com.expedia.pitchfork.systems.common.SpanForwarder;
-import com.expedia.pitchfork.systems.haystack.SpanValidator;
+import com.expedia.pitchfork.systems.common.SpanValidator;
 import com.expedia.pitchfork.systems.common.IngressDecoder;
 import io.micrometer.core.instrument.Counter;
 import org.slf4j.Logger;

--- a/src/main/java/com/expedia/pitchfork/systems/datadog/forwarder/DatadogSpansDispatcher.java
+++ b/src/main/java/com/expedia/pitchfork/systems/datadog/forwarder/DatadogSpansDispatcher.java
@@ -106,9 +106,9 @@ public class DatadogSpansDispatcher implements Runnable {
 
                 successCounter.increment(spans.size());
             });
-        } catch (Exception e) {
+        } catch (RuntimeException up) {
             failureCounter.increment(spans.size());
-            throw new RuntimeException(e);
+            throw up;
         } finally {
             spans.clear();
         }

--- a/src/main/java/com/expedia/pitchfork/systems/datadog/forwarder/DatadogSpansDispatcher.java
+++ b/src/main/java/com/expedia/pitchfork/systems/datadog/forwarder/DatadogSpansDispatcher.java
@@ -1,11 +1,13 @@
 package com.expedia.pitchfork.systems.datadog.forwarder;
 
+import com.expedia.pitchfork.monitoring.metrics.MetersProvider;
 import com.expedia.pitchfork.systems.datadog.DatadogDomainConverter;
-import com.expedia.pitchfork.systems.datadog.model.DatadogSpan;
 import com.expedia.pitchfork.systems.datadog.forwarder.properties.DatadogForwarderConfigProperties;
+import com.expedia.pitchfork.systems.datadog.model.DatadogSpan;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import io.micrometer.core.instrument.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,13 +38,18 @@ public class DatadogSpansDispatcher implements Runnable {
     private final WebClient datadogClient;
     private final ObjectWriter mapper;
     private final ArrayBlockingQueue<Span> pending;
+    private final Counter successCounter;
+    private final Counter failureCounter;
 
     public DatadogSpansDispatcher(WebClient datadogClient,
                                   ObjectMapper mapper,
-                                  DatadogForwarderConfigProperties properties) {
+                                  DatadogForwarderConfigProperties properties,
+                                  MetersProvider metersProvider) {
         this.datadogClient = datadogClient;
         this.mapper = mapper.writer();
         this.pending = new ArrayBlockingQueue<>(properties.getQueuedMaxSpans());
+        this.successCounter = metersProvider.forwarderCounter("datadog", true);
+        this.failureCounter = metersProvider.forwarderCounter("datadog", false);
     }
 
     @Override
@@ -88,16 +95,23 @@ public class DatadogSpansDispatcher implements Runnable {
 
         Optional<String> body = serialize(datadogSpans);
 
-        body.ifPresent(it -> {
-            datadogClient.put()
-                    .uri("/v0.3/traces")
-                    .body(fromValue(it))
-                    .retrieve()
-                    .toBodilessEntity()
-                    .subscribe(); // FIXME: reactive
-        });
+        try {
+            body.ifPresent(it -> {
+                datadogClient.put()
+                        .uri("/v0.3/traces")
+                        .body(fromValue(it))
+                        .retrieve()
+                        .toBodilessEntity()
+                        .subscribe(); // FIXME: reactive
 
-        spans.clear();
+                successCounter.increment(spans.size());
+            });
+        } catch (Exception e) {
+            failureCounter.increment(spans.size());
+            throw new RuntimeException(e);
+        } finally {
+            spans.clear();
+        }
     }
 
     private Optional<String> serialize(List<DatadogSpan> spans) {
@@ -106,6 +120,7 @@ public class DatadogSpansDispatcher implements Runnable {
             return Optional.ofNullable(body);
         } catch (JsonProcessingException e) {
             logger.error("operation=serialize", e);
+            failureCounter.increment(spans.size());
             return Optional.empty();
         }
     }
@@ -116,8 +131,9 @@ public class DatadogSpansDispatcher implements Runnable {
     public void addSpan(Span span) {
         try {
             this.pending.add(span);
-        } catch (Exception e) {
-            logger.error("operation=addSpan", e);
+        } catch (IllegalStateException e) {
+            failureCounter.increment();
+            logger.error("Unable to add span with id {} to queue. Queue full.", span.id());
         }
     }
 }

--- a/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/kafka/KafkaConsumerLoop.java
+++ b/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/kafka/KafkaConsumerLoop.java
@@ -17,7 +17,7 @@
 package com.expedia.pitchfork.systems.zipkin.ingress.kafka;
 
 import com.expedia.pitchfork.systems.common.Fork;
-import com.expedia.pitchfork.systems.haystack.SpanValidator;
+import com.expedia.pitchfork.systems.common.SpanValidator;
 import com.expedia.pitchfork.systems.zipkin.ingress.kafka.properties.KafkaIngressConfigProperties;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/kafka/KafkaConsumerSpringConfig.java
+++ b/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/kafka/KafkaConsumerSpringConfig.java
@@ -17,7 +17,7 @@
 package com.expedia.pitchfork.systems.zipkin.ingress.kafka;
 
 import com.expedia.pitchfork.systems.common.Fork;
-import com.expedia.pitchfork.systems.haystack.SpanValidator;
+import com.expedia.pitchfork.systems.common.SpanValidator;
 import com.expedia.pitchfork.systems.zipkin.ingress.kafka.properties.KafkaIngressConfigProperties;
 import com.expedia.pitchfork.monitoring.metrics.MetersProvider;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/kafka/KafkaRecordsConsumer.java
+++ b/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/kafka/KafkaRecordsConsumer.java
@@ -17,7 +17,7 @@
 package com.expedia.pitchfork.systems.zipkin.ingress.kafka;
 
 import com.expedia.pitchfork.systems.common.Fork;
-import com.expedia.pitchfork.systems.haystack.SpanValidator;
+import com.expedia.pitchfork.systems.common.SpanValidator;
 import com.expedia.pitchfork.systems.zipkin.ingress.kafka.properties.KafkaIngressConfigProperties;
 import com.expedia.pitchfork.monitoring.metrics.MetersProvider;
 import io.micrometer.core.instrument.Counter;

--- a/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/rabbitmq/RabbitMqConsumer.java
+++ b/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/rabbitmq/RabbitMqConsumer.java
@@ -17,7 +17,7 @@
 package com.expedia.pitchfork.systems.zipkin.ingress.rabbitmq;
 
 import com.expedia.pitchfork.systems.common.Fork;
-import com.expedia.pitchfork.systems.haystack.SpanValidator;
+import com.expedia.pitchfork.systems.common.SpanValidator;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;

--- a/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/rabbitmq/RabbitMqIngressSpringConfig.java
+++ b/src/main/java/com/expedia/pitchfork/systems/zipkin/ingress/rabbitmq/RabbitMqIngressSpringConfig.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.expedia.pitchfork.systems.haystack.SpanValidator;
+import com.expedia.pitchfork.systems.common.SpanValidator;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,6 +11,11 @@
       "description": "Max allowed difference between now and the timestamp of a given span. If a span has a timestamp outside of this range it will be discarded. Use -1 to disable this validation."
     },
     {
+      "name": "pitchfork.validators.invalid-service-names",
+      "type": "java.util.List",
+      "description": "Array with disallowed service names."
+    },
+    {
       "name": "pitchfork.ingress.rabbitmq.enabled",
       "type": "java.lang.Boolean",
       "description": "When true, uses RabbitMq as a source for Zipkin spans."

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ server:
 logging.pattern.console: "%d{&quot;yyyy-MM-dd'T'HH:mm:ss.SSSZ&quot;} %highlight(%-5level) [%thread] rid=[%X{rid}] %logger{36} - %msg %rEx{30}%n"
 pitchfork:
   validators:
+    invalid-service-names: "unknown"
     accept-null-timestamps: true
     max-timestamp-drift-seconds: -1
   ingress:

--- a/src/test/java/com/expedia/pitchfork/integration/HaystackKafkaForwarderTest.java
+++ b/src/test/java/com/expedia/pitchfork/integration/HaystackKafkaForwarderTest.java
@@ -19,6 +19,7 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.Endpoint;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
@@ -40,7 +41,7 @@ import static org.assertj.core.api.Assertions.fail;
 class HaystackKafkaForwarderTest {
 
     @Container
-    private static final KafkaContainer kafkaContainer = new KafkaContainer();
+    private static final KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka").withTag("5.4.3"));
 
     @LocalServerPort
     private int localServerPort;

--- a/src/test/java/com/expedia/pitchfork/systems/common/SpanValidatorTest.java
+++ b/src/test/java/com/expedia/pitchfork/systems/common/SpanValidatorTest.java
@@ -1,36 +1,54 @@
 package com.expedia.pitchfork.systems.common;
 
+import com.expedia.pitchfork.monitoring.metrics.MetersProvider;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+import java.util.stream.Stream;
+
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.util.stream.Stream;
-
-import com.expedia.pitchfork.monitoring.metrics.MetersProvider;
-import com.expedia.pitchfork.systems.common.SpanValidator;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import io.micrometer.core.instrument.Counter;
-import zipkin2.Endpoint;
-import zipkin2.Span;
-
 public class SpanValidatorTest {
 
     private static final boolean ACCEPT_NULL_TIMESTAMPS = true;
     private static final boolean REJECT_NULL_TIMESTAMPS = false;
-    private static final int MAX_DRIFT_FOR_TIMESTAMPS_DISABLED = -1;
-    private static final boolean DISABLE_NULL_TIMESTAMPS_VALIDATION = false;
     private static final int DISABLE_TIMESTAMP_DRIFT_VALIDATION = -1;
     private static final String[] DISABLE_INVALID_SERVICE_NAMES = new String[]{};
     private final MetersProvider metersProvider = mock(MetersProvider.class);
     private final Counter mockCounter = mock(Counter.class);
+
+    private static Stream<Arguments> serviceNames() {
+        return Stream.of(
+                Arguments.of(true, "unknown", new String[]{""}), // accept if invalid service names list is empty
+                Arguments.of(false, "unknown", new String[]{"unknown"}) // accept if service name is in the list of invalid names
+        );
+    }
+
+    private static Stream<Arguments> driftTimestamps() {
+        return Stream.of(
+                Arguments.of(5, currentTimeMillis() - SECONDS.toMillis(10), false), // reject span if too old
+                Arguments.of(5, currentTimeMillis() + SECONDS.toMillis(10), false), // reject span if too recent
+                Arguments.of(10, currentTimeMillis() + SECONDS.toMillis(5), true) // accept if only 5 sec in the future
+        );
+    }
+
+    private static Stream<Arguments> nullTimestamps() {
+        return Stream.of(
+                Arguments.of(REJECT_NULL_TIMESTAMPS, null, false), // reject null timestamp
+                Arguments.of(REJECT_NULL_TIMESTAMPS, 123L, true), // accept non null timestamp
+                Arguments.of(ACCEPT_NULL_TIMESTAMPS, null, true) // accept null timestamp if validation is disabled
+        );
+    }
 
     @BeforeEach
     public void setup() {
@@ -40,16 +58,34 @@ public class SpanValidatorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("timestamps")
-    public void shouldDiscardSpanIfTimestampIsInvalid(boolean rejectNullTimestamps, int maxDrift, Long timestamp, boolean spanIsKept) {
+    @MethodSource("nullTimestamps")
+    public void shouldDiscardSpanIfTimestampIsNull(boolean enableValidation, Long timestamp, boolean spanIsKept) {
         zipkin2.Span zipkinSpan = Span.newBuilder()
                 .traceId(zipkinTraceId(123L))
                 .id(zipkinSpanId(456L))
-                .localEndpoint(Endpoint.newBuilder().serviceName("unknown").build())
+                .localEndpoint(Endpoint.newBuilder().serviceName("hello").build())
+                .timestamp(timestamp)
+                .build();
+
+        var victim = new SpanValidator(enableValidation, DISABLE_TIMESTAMP_DRIFT_VALIDATION, DISABLE_INVALID_SERVICE_NAMES, metersProvider);
+        victim.initialize();
+
+        boolean isSpanValid = victim.isSpanValid(zipkinSpan);
+
+        assertEquals(isSpanValid, spanIsKept);
+    }
+
+    @ParameterizedTest
+    @MethodSource("driftTimestamps")
+    public void shouldDiscardSpanIfTimestampDriftIsTooHigh(int maxDrift, Long timestamp, boolean spanIsKept) {
+        zipkin2.Span zipkinSpan = Span.newBuilder()
+                .traceId(zipkinTraceId(123L))
+                .id(zipkinSpanId(456L))
+                .localEndpoint(Endpoint.newBuilder().serviceName("hello").build())
                 .timestamp(timestamp != null ? timestamp * 1000 : null) // millis to micros
                 .build();
 
-        var victim = new SpanValidator(rejectNullTimestamps, maxDrift, DISABLE_INVALID_SERVICE_NAMES, metersProvider);
+        var victim = new SpanValidator(ACCEPT_NULL_TIMESTAMPS, maxDrift, DISABLE_INVALID_SERVICE_NAMES, metersProvider);
         victim.initialize();
 
         boolean isSpanValid = victim.isSpanValid(zipkinSpan);
@@ -67,31 +103,12 @@ public class SpanValidatorTest {
                 .timestamp(System.currentTimeMillis())
                 .build();
 
-        var victim = new SpanValidator(DISABLE_NULL_TIMESTAMPS_VALIDATION, DISABLE_TIMESTAMP_DRIFT_VALIDATION, invalidServiceNames, metersProvider);
+        var victim = new SpanValidator(ACCEPT_NULL_TIMESTAMPS, DISABLE_TIMESTAMP_DRIFT_VALIDATION, invalidServiceNames, metersProvider);
         victim.initialize();
 
         boolean isSpanValid = victim.isSpanValid(zipkinSpan);
 
         assertEquals(isSpanValid, spanIsKept);
-    }
-
-    private static Stream<Arguments> serviceNames() {
-        return Stream.of(
-                Arguments.of(true, "unknown", new String[]{""}), // accept if invalid service names list is empty
-                Arguments.of(false, "unknown", new String[]{"unknown"}) // accept if service name is in the list of invalid names
-        );
-    }
-
-    private static Stream<Arguments> timestamps() {
-        return Stream.of(
-                Arguments.of(REJECT_NULL_TIMESTAMPS, MAX_DRIFT_FOR_TIMESTAMPS_DISABLED, null, false), // reject null timestamp
-                Arguments.of(ACCEPT_NULL_TIMESTAMPS, MAX_DRIFT_FOR_TIMESTAMPS_DISABLED, null, true), // accept null timestamp
-                Arguments.of(REJECT_NULL_TIMESTAMPS, MAX_DRIFT_FOR_TIMESTAMPS_DISABLED, 123L, true), // accept non null timestamp
-                Arguments.of(REJECT_NULL_TIMESTAMPS, 5, currentTimeMillis() - SECONDS.toMillis(10), false), // reject span if too old
-                Arguments.of(REJECT_NULL_TIMESTAMPS, 5, currentTimeMillis() + SECONDS.toMillis(10), false), // reject span if too recent
-                Arguments.of(REJECT_NULL_TIMESTAMPS, 10, currentTimeMillis() + SECONDS.toMillis(5), true), // accept if only 5 sec in the future
-                Arguments.of(REJECT_NULL_TIMESTAMPS, 10, currentTimeMillis() - SECONDS.toMillis(5), true)
-        );
     }
 
     /**

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,6 +2,7 @@ server:
   port: 9411
 pitchfork:
   validators:
+    invalid-service-names: "unknown"
     accept-null-timestamps: true
     max-timestamp-drift-seconds: -1
   ingress:


### PR DESCRIPTION
### :pencil: Description
- Add additional validator for invalid service names and metrics for datadog forwarder
- Move common validators to correct package (and out of haystacKk)